### PR TITLE
Add options to platform-tag the generated file

### DIFF
--- a/blender/distutils/bdist_blender_addon.py
+++ b/blender/distutils/bdist_blender_addon.py
@@ -1,6 +1,7 @@
 from distutils.core import Command
 from distutils.dir_util import copy_tree, remove_tree, mkpath
 from distutils.file_util import copy_file, write_file
+from distutils.util import get_platform
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -17,16 +18,22 @@ def spec2path(spec):
 class bdist_blender_addon(Command):
     description = "Build Blender addon"
     user_options = [
-        ('addon-require=', None, 'Specify the packages to be copied and distributed with the Blender addon')
+        ('addon-require=', None, 'Specify the packages to be copied and distributed with the Blender addon'),
+        ('tag-plat', None, 'Add the platform name to the generated filename'),
+        ('plat-name=', None, 'Platform name to embed in generated filenames (default: {})'.format(get_platform())),
     ]
     sub_commands = (('build', lambda self: True),)
 
     def initialize_options(self):
         self.addon_require = []
+        self.tag_plat = None
+        self.plat_name = None
 
     def finalize_options(self):
         v = self.addon_require
         self.addon_require = v.split(',') if type(v) is str else v
+        if self.plat_name is None:
+            self.plat_name = get_platform()
 
     def run(self):
         for cmd_name in self.get_sub_commands():
@@ -35,6 +42,8 @@ class bdist_blender_addon(Command):
         addon_name = self.distribution.get_name()
         dist_dir = Path(self.get_finalized_command('bdist').dist_dir)
         archive_name = '{}-v{}'.format(addon_name, self.distribution.get_version())
+        if self.tag_plat:
+            archive_name = '{}.{}'.format(archive_name, self.plat_name)
         addon_archive = dist_dir / archive_name
         build_lib = Path(self.get_finalized_command('build').build_lib)
         build_addon = build_lib / addon_name


### PR DESCRIPTION
This adds the options "tag-plat" to enable the platform tagging (disabled by default) and "plat-name" to override the detected platform name.

I am planning on using this to build a Blender addon that uses a native extension module, so having the platform name in the generated filename is useful.